### PR TITLE
Moved phpunit to require-dev to avoid version conflicts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,10 @@
   ],
   "require": {
     "php" : "^5.6|^7.0",
-    "phpunit/phpunit": "^5.7",
     "guzzlehttp/guzzle": "~6.0"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^5.7"
   },
   "autoload": {
     "psr-0": {


### PR DESCRIPTION
When I add your API as a dependency in composer, it causes a conflict with my own phpunit dependency.
I think phpunit can be moved in require-dev to avoid this conflict.
